### PR TITLE
fix: default allowed-origins value

### DIFF
--- a/config/cors.go
+++ b/config/cors.go
@@ -16,7 +16,7 @@ func init() {
 		// To learn more: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
 		"paths":                []string{"*"},
 		"allowed_methods":      []string{"*"},
-		"allowed_origins":      []string{"*"},
+		"allowed_origins":      []string{"127.0.0.1:3000"},
 		"allowed_headers":      []string{"*"},
 		"exposed_headers":      []string{""},
 		"max_age":              0,


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/457

I defined it in ```allowed-origins``` because ```127.0.0.1:3000``` is the default.

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
@coderabbitai summary
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
