### PR TITLE
fix: database timezone

### DIFF
--- a/database/migrations/20240915060148_create_users_table.go
+++ b/database/migrations/20240915060148_create_users_table.go
@@ -20,7 +20,7 @@ func (r *M20240915060148CreateUsersTable) Up() error {
 		table.String("name")
 		table.String("email")
 		table.String("password")
-		table.Timestamps()
+		table.TimestampsTz()
 	})
 }
 


### PR DESCRIPTION
## 📑 Description

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

Currently, for `Timestamps` column of Postgres and Sqlserver, `2025-06-05 14:46:29 +08:00` will be saved with `2025-06-05 14:46:29`, but when reading, ORM considers that the timezone is UTC, the timezone metadata is missed.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
