### PR TITLE
chore: optimize Dockerfile with ldflags and cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,18 @@
 FROM golang:alpine AS builder
 
 ENV GO111MODULE=on \
-    CGO_ENABLED=0  \
-    GOARCH="amd64" \
-    GOOS=linux
+    CGO_ENABLED=0
 
 WORKDIR /build
 COPY . .
 RUN go mod tidy
-RUN go build --ldflags "-extldflags -static" -o main .
+RUN go build --ldflags "-s -w -extldflags -static" -o main .
 
 FROM alpine:latest
 
 WORKDIR /www
 
 COPY --from=builder /build/main /www/
-COPY --from=builder /build/database/ /www/database/
 COPY --from=builder /build/public/ /www/public/
 COPY --from=builder /build/storage/ /www/storage/
 COPY --from=builder /build/resources/ /www/resources/


### PR DESCRIPTION
## 📑 Description

<img width="984" alt="image" src="https://github.com/user-attachments/assets/78e5cfbd-2d16-46d2-8b02-2ab7ae19e5f6" />


- Removed explicit `GOARCH` and `GOOS` environment variables, as their values are
inferred from the base image (golang:alpine), which already builds for linux/amd64
by default in this context.

- Added `-s -w` to `ldflags` to strip debug and symbol information from the binary,
reducing its size and improving container efficiency for production use.

- Also removed the unused COPY of the` /build/database` directory to avoid including
unnecessary files in the final image.

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
