### PR TITLE
Fix: Use buffered channel for signal handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 	bootstrap.Boot()
 
 	// Create a channel to listen for OS signals
-	quit := make(chan os.Signal)
+	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 
 	// Start http server by facades.Route().


### PR DESCRIPTION
## 📑 Description
- Changed `quit` channel from unbuffered to buffered (capacity: 1)

## Why
- Prevents potential signal loss during graceful shutdown
- Follows Go best practices for signal.Notify usage


<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

## Impact
- No breaking changes
- Improves reliability of graceful shutdown handling
