### PR TITLE
feat(grpc): Add recovery interceptor for improved server stability

### DIFF
--- a/app/grpc/kernel.go
+++ b/app/grpc/kernel.go
@@ -32,7 +32,7 @@ func recoveryInterceptor() grpc.UnaryServerInterceptor {
 		defer func() {
 			if r := recover(); r != nil {
 				facades.Log().Errorf("gRPC panic recovered: %v\n%s", r, debug.Stack())
-				er	r = status.Errorf(codes.Internal, "internal server error")
+				err = status.Errorf(codes.Internal, "internal server error")
 			}
 		}()
 		return handler(ctx, req)


### PR DESCRIPTION
## 📑 Description

Adds a recovery interceptor to the gRPC kernel that catches panics in handlers, 
logs them with stack traces, and returns proper gRPC internal errors instead of 
crashing the server. This improves reliability in production environments.

