### PR TITLE
chore(scripts): make artisan shebang portable across systems

### DIFF
--- a/artisan
+++ b/artisan
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 go run . artisan "$@"


### PR DESCRIPTION
## 📑 Description

This PR updates the artisan script shebang from` #!/bin/bash` to `#!/usr/bin/env bash` to improve portability across systems, including NixOS and other Unix-like environments where Bash may not be located at /bin/bash.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code (not applicable for this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR improves the portability of the `artisan` script by updating its shebang line from a fixed path to use the `env` command for locating the Bash interpreter.

## Changes

**artisan script:**
- Updated shebang from `#!/bin/bash` to `#!/usr/bin/env bash`

This change allows the script to work correctly on systems where Bash is installed in non-standard locations (such as NixOS and other Unix-like environments), rather than assuming Bash is always available at `/bin/bash`. The script functionality remains unchanged—it continues to execute `go run . artisan "$@"` with the provided arguments.

## Impact

- **Portability:** The script now works on a wider range of Unix-like systems with different Bash installation paths
- **Compatibility:** No breaking changes; systems with Bash at the standard `/bin/bash` path are unaffected
- **Lines Changed:** 1 insertion, 1 deletion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->